### PR TITLE
Refactor payment gateway

### DIFF
--- a/lib/payonline/payment_gateway.rb
+++ b/lib/payonline/payment_gateway.rb
@@ -1,43 +1,13 @@
 module Payonline
   class PaymentGateway
-    class Params < SimpleDelegator
-      REQUIRED_PARAMS = %w(
-        order_id amount currency valid_until
-        order_description return_url fail_url return_url
-      )
-
-      def initialize(params)
-        @params = prepare_params(params)
-
-        filter_params
-
-        __setobj__ @params
-      end
-
-      def to_query
-        @params.each_with_object({}) do |(k, v), params|
-          params[k.camelize] = v
-        end.to_query
-      end
-
-      private
-
-      def prepare_params(params)
-        params[:amount] = '%.2f' % params[:amount]
-
-        params.merge(
-          return_url: Payonline.configuration.return_url,
-          fail_url: Payonline.configuration.fail_url
-        )
-      end
-
-      def filter_params
-        @params.select! { |key, value| REQUIRED_PARAMS.include?(key) && value }
-      end
-    end
-
     SIGNED_PARAMS = %w(order_id amount currency valid_until order_description)
     BASE_URL = 'https://secure.payonlinesystem.com'
+
+    REQUIRED_PARAMS = %w(
+      order_id amount currency valid_until
+      order_description return_url fail_url return_url
+    )
+
     PAYMENT_TYPE_URL = {
       qiwi: 'select/qiwi/',
       webmoney: 'select/webmoney/',
@@ -46,13 +16,29 @@ module Payonline
     }
 
     def initialize(params = {})
-      @params = Params.new(params.with_indifferent_access)
+      @params = prepare_params(params)
     end
 
     def payment_url(type: :card, language: :ru)
       params = Payonline::Signature.sign_params(@params, SIGNED_PARAMS)
 
       "#{BASE_URL}/#{language}/payment/#{PAYMENT_TYPE_URL[type]}?#{params.to_query}"
+    end
+
+    private
+
+    def prepare_params(params)
+      params.with_indifferent_access
+        .slice(*REQUIRED_PARAMS)
+        .merge(default_params)
+        .merge(amount: '%.2f' % params[:amount])
+    end
+
+    def default_params
+      {
+        return_url: Payonline.configuration.return_url,
+        fail_url: Payonline.configuration.fail_url
+      }
     end
   end
 end

--- a/lib/payonline/signature.rb
+++ b/lib/payonline/signature.rb
@@ -13,8 +13,7 @@ module Payonline
       digest = self.digest(params, keys)
       params['security_key'] = digest
       params['content_type'] = 'text'
-
-      params
+      params.transform_keys { |key| key.to_s.camelize }
     end
   end
 end

--- a/payonline.gemspec
+++ b/payonline.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'activesupport', '~> 4.2.6'
   spec.add_development_dependency 'rake', '~> 11.2'
 end


### PR DESCRIPTION
Sorry for so many PRs :)
- Refactor `Params` class into `PaymentGateway` methods
- Require `ActiveSupport` in gem spec, since some of its' methods are used (like `with_indifferent_access`)
- Remove Bundler dependency
